### PR TITLE
fix: multipart response content-type header remove new lines and tabs

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportIntegration.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportIntegration.java
@@ -61,7 +61,9 @@ public class ReportIntegration extends EndpointRouteBuilder {
             .setBody(exchangeProperty(Constants.REPORT_PROPERTY))
             .bean(ReportTransformer.class, "filterVerboseResult")
             .marshal().json()
-            .marshal().mimeMultipart(Constants.MULTIPART_MIXED_TYPE.getSubtype(), false, false, true);
+            .marshal().mimeMultipart(Constants.MULTIPART_MIXED_TYPE.getSubtype(), false, false, true)
+            // original Content-Type header contains special characters that breaks java's built-in http client
+            .setHeader(Exchange.CONTENT_TYPE, header(Exchange.CONTENT_TYPE).regexReplaceAll("[\t|\r|\n]", ""));
 
         from(direct("jsonReport"))
             .routeId("jsonReport")


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

The _Content-Type_ header when using _multipart_ type responses contains a new line and a tab for including the attributes map. This breaks _Java_'s built-in http client.

More info can be found in https://github.com/TomerFi/backend-multipart.
This PR resolves https://issues.redhat.com/browse/APPENG-1864.

Fixes #71 
