### PR TITLE
fix: remove extra line in report and add purl to openapi

### DIFF
--- a/src/main/resources/META-INF/openapi.yaml
+++ b/src/main/resources/META-INF/openapi.yaml
@@ -208,6 +208,10 @@ components:
     PackageRef:
       type: object
       properties:
+        purl:
+          type: string
+          description: PackageURL identifier
+          example: pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1
         name:
           type: string
           description: <groupId>:<artifactId> for Java packages

--- a/src/main/resources/freemarker/templates/report.ftl
+++ b/src/main/resources/freemarker/templates/report.ftl
@@ -224,7 +224,6 @@
                                 Sign up for a free Snyk account
                             </a>to learn about the vulnerabilities found
                         </#if>
-                        
                     </td>
                 <#else>
                     <td>--</td>

--- a/src/test/resources/__files/reports/report_all_no_snyk_token.html
+++ b/src/test/resources/__files/reports/report_all_no_snyk_token.html
@@ -237,7 +237,6 @@
                             target="_blank">
                                 SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244
                             </a>
-                        
                     </td>
                 <td>
                             <div>
@@ -432,7 +431,6 @@
                             target="_blank">
                                 SNYK-JAVA-ORGPOSTGRESQL-3146847
                             </a>
-                        
                     </td>
                 <td>
                             <div>

--- a/src/test/resources/__files/reports/report_all_token.html
+++ b/src/test/resources/__files/reports/report_all_token.html
@@ -237,7 +237,6 @@
                             target="_blank">
                                 SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244
                             </a>
-                        
                     </td>
                 <td>
                             <div>
@@ -549,7 +548,6 @@
                             target="_blank">
                                 SNYK-JAVA-ORGPOSTGRESQL-3146847
                             </a>
-                        
                     </td>
                 <td>
                             <div>


### PR DESCRIPTION
The [exhort-java-api](https://github.com/RHEcosystemAppEng/exhort-java-api) Integration Tests were failing because of a missing field in the OpenAPI