### PR TITLE
Css report fix

### DIFF
--- a/src/main/resources/freemarker/templates/report.ftl
+++ b/src/main/resources/freemarker/templates/report.ftl
@@ -18,6 +18,7 @@
         </g>
     </symbol>
 </svg>
+<?xml version="1.0" encoding="UTF-8"?>
 <#function htmlRef package>
     <#local result = package.name()?replace(".", "")>
     <#local result = result?replace(":","")>
@@ -48,14 +49,8 @@
     <#include "styles.ftl">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="fonts.css"/>
     <!-- Include latest PatternFly CSS via CDN -->
-    <link
-            rel="stylesheet"
-            href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
-            crossorigin="anonymous"
-    />
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@2/patternfly.css" crossorigin />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
           integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <title>Dependency Analysis</title>
@@ -64,11 +59,14 @@
 
 <div class="card">
     <div class="card-header">
-        <span class="pf-c-icon">
-          <span class="pf-c-icon__content pf-m-warning">
-            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-          </span>
-        </span>
+        <svg width="31px" height="25px" viewBox="0 0 61 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="padding-bottom: 5px">
+            <title></title>
+            <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Icons-/-4.-Size-xl-/-Status-/-exclamation-triangle" fill="#F0AB00">
+                    <path d="M55.6811464,54.9998718 C59.5692673,54.9998718 62.0128612,50.7818528 60.0661228,47.4074788 L34.7600689,3.52969955 C32.8158025,0.159857423 27.9375754,0.153677628 25.9899101,3.52969955 L0.683135242,47.4074788 C-1.25979225,50.775364 1.17257499,54.9998718 5.06821466,54.9998718 L55.6811464,54.9998718 Z M32.9350725,36.437416 L27.8149065,36.437416 C27.1427508,36.437416 26.5878052,35.9119275 26.5512414,35.2408018 L25.7688794,20.897086 C25.7293287,20.172093 26.3064186,19.5624563 27.0324415,19.5624563 L33.7174345,19.5624563 C34.4434574,19.5624563 35.0206503,20.172093 34.9810996,20.897086 L34.1987376,35.2408018 C34.1621738,35.9119275 33.6072282,36.437416 32.9350725,36.437416 Z M30.3749895,48.0389509 C27.6955335,48.0389509 25.5234386,45.866856 25.5234386,43.1873999 C25.5234386,40.5079439 27.6955335,38.335849 30.3749895,38.335849 C33.0544455,38.335849 35.2265404,40.5079439 35.2265404,43.1873999 C35.2265404,45.866856 33.0544455,48.0389509 30.3749895,48.0389509 Z" id="exclamation-triangle"></path>
+                </g>
+            </g>
+        </svg>
         <span style="font-size: larger">&nbsp; Security Issues</span>
 
     </div>
@@ -81,19 +79,25 @@
                 <p style="font-size: larger">Dependencies with security issues in your stack.</p>
                 <p>Dependencies with high common vulnerabilities and exposures (CVE) score.</p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-info">
-                          <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#2b9af3">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Total Vulnerabilities: ${body.report.getSummary().getVulnerabilities().getTotal()}
                 </p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-warning">
-                        <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#f0ab00">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Vulnerable Dependencies: ${body.report.getSummary().getVulnerabilities().getDirect()}
                 </p>
             </div>

--- a/src/test/resources/__files/reports/report_all_no_snyk_token.html
+++ b/src/test/resources/__files/reports/report_all_no_snyk_token.html
@@ -18,6 +18,7 @@
         </g>
     </symbol>
 </svg>
+<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/html">
 <head>
 <style type="text/css">
@@ -121,14 +122,8 @@
     /*#snyk {background-color: lightgreen;}*/
 </style>    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="fonts.css"/>
     <!-- Include latest PatternFly CSS via CDN -->
-    <link
-            rel="stylesheet"
-            href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
-            crossorigin="anonymous"
-    />
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@2/patternfly.css" crossorigin />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
           integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <title>Dependency Analysis</title>
@@ -137,11 +132,14 @@
 
 <div class="card">
     <div class="card-header">
-        <span class="pf-c-icon">
-          <span class="pf-c-icon__content pf-m-warning">
-            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-          </span>
-        </span>
+        <svg width="31px" height="25px" viewBox="0 0 61 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="padding-bottom: 5px">
+            <title></title>
+            <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Icons-/-4.-Size-xl-/-Status-/-exclamation-triangle" fill="#F0AB00">
+                    <path d="M55.6811464,54.9998718 C59.5692673,54.9998718 62.0128612,50.7818528 60.0661228,47.4074788 L34.7600689,3.52969955 C32.8158025,0.159857423 27.9375754,0.153677628 25.9899101,3.52969955 L0.683135242,47.4074788 C-1.25979225,50.775364 1.17257499,54.9998718 5.06821466,54.9998718 L55.6811464,54.9998718 Z M32.9350725,36.437416 L27.8149065,36.437416 C27.1427508,36.437416 26.5878052,35.9119275 26.5512414,35.2408018 L25.7688794,20.897086 C25.7293287,20.172093 26.3064186,19.5624563 27.0324415,19.5624563 L33.7174345,19.5624563 C34.4434574,19.5624563 35.0206503,20.172093 34.9810996,20.897086 L34.1987376,35.2408018 C34.1621738,35.9119275 33.6072282,36.437416 32.9350725,36.437416 Z M30.3749895,48.0389509 C27.6955335,48.0389509 25.5234386,45.866856 25.5234386,43.1873999 C25.5234386,40.5079439 27.6955335,38.335849 30.3749895,38.335849 C33.0544455,38.335849 35.2265404,40.5079439 35.2265404,43.1873999 C35.2265404,45.866856 33.0544455,48.0389509 30.3749895,48.0389509 Z" id="exclamation-triangle"></path>
+                </g>
+            </g>
+        </svg>
         <span style="font-size: larger">&nbsp; Security Issues</span>
 
     </div>
@@ -154,19 +152,25 @@
                 <p style="font-size: larger">Dependencies with security issues in your stack.</p>
                 <p>Dependencies with high common vulnerabilities and exposures (CVE) score.</p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-info">
-                          <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#2b9af3">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Total Vulnerabilities: 4
                 </p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-warning">
-                        <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#f0ab00">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Vulnerable Dependencies: 2
                 </p>
             </div>

--- a/src/test/resources/__files/reports/report_all_token.html
+++ b/src/test/resources/__files/reports/report_all_token.html
@@ -18,6 +18,7 @@
         </g>
     </symbol>
 </svg>
+<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/html">
 <head>
 <style type="text/css">
@@ -121,14 +122,8 @@
     /*#snyk {background-color: lightgreen;}*/
 </style>    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="fonts.css"/>
     <!-- Include latest PatternFly CSS via CDN -->
-    <link
-            rel="stylesheet"
-            href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
-            crossorigin="anonymous"
-    />
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@2/patternfly.css" crossorigin />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
           integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <title>Dependency Analysis</title>
@@ -137,11 +132,14 @@
 
 <div class="card">
     <div class="card-header">
-        <span class="pf-c-icon">
-          <span class="pf-c-icon__content pf-m-warning">
-            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-          </span>
-        </span>
+        <svg width="31px" height="25px" viewBox="0 0 61 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="padding-bottom: 5px">
+            <title></title>
+            <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Icons-/-4.-Size-xl-/-Status-/-exclamation-triangle" fill="#F0AB00">
+                    <path d="M55.6811464,54.9998718 C59.5692673,54.9998718 62.0128612,50.7818528 60.0661228,47.4074788 L34.7600689,3.52969955 C32.8158025,0.159857423 27.9375754,0.153677628 25.9899101,3.52969955 L0.683135242,47.4074788 C-1.25979225,50.775364 1.17257499,54.9998718 5.06821466,54.9998718 L55.6811464,54.9998718 Z M32.9350725,36.437416 L27.8149065,36.437416 C27.1427508,36.437416 26.5878052,35.9119275 26.5512414,35.2408018 L25.7688794,20.897086 C25.7293287,20.172093 26.3064186,19.5624563 27.0324415,19.5624563 L33.7174345,19.5624563 C34.4434574,19.5624563 35.0206503,20.172093 34.9810996,20.897086 L34.1987376,35.2408018 C34.1621738,35.9119275 33.6072282,36.437416 32.9350725,36.437416 Z M30.3749895,48.0389509 C27.6955335,48.0389509 25.5234386,45.866856 25.5234386,43.1873999 C25.5234386,40.5079439 27.6955335,38.335849 30.3749895,38.335849 C33.0544455,38.335849 35.2265404,40.5079439 35.2265404,43.1873999 C35.2265404,45.866856 33.0544455,48.0389509 30.3749895,48.0389509 Z" id="exclamation-triangle"></path>
+                </g>
+            </g>
+        </svg>
         <span style="font-size: larger">&nbsp; Security Issues</span>
 
     </div>
@@ -154,19 +152,25 @@
                 <p style="font-size: larger">Dependencies with security issues in your stack.</p>
                 <p>Dependencies with high common vulnerabilities and exposures (CVE) score.</p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-info">
-                          <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#2b9af3">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Total Vulnerabilities: 7
                 </p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-warning">
-                        <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#f0ab00">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Vulnerable Dependencies: 2
                 </p>
             </div>

--- a/src/test/resources/__files/reports/report_error.html
+++ b/src/test/resources/__files/reports/report_error.html
@@ -18,6 +18,7 @@
         </g>
     </symbol>
 </svg>
+<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/html">
 <head>
 <style type="text/css">
@@ -121,14 +122,8 @@
     /*#snyk {background-color: lightgreen;}*/
 </style>    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="fonts.css"/>
     <!-- Include latest PatternFly CSS via CDN -->
-    <link
-            rel="stylesheet"
-            href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
-            crossorigin="anonymous"
-    />
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@2/patternfly.css" crossorigin />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
           integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <title>Dependency Analysis</title>
@@ -137,11 +132,14 @@
 
 <div class="card">
     <div class="card-header">
-        <span class="pf-c-icon">
-          <span class="pf-c-icon__content pf-m-warning">
-            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-          </span>
-        </span>
+        <svg width="31px" height="25px" viewBox="0 0 61 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="padding-bottom: 5px">
+            <title></title>
+            <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Icons-/-4.-Size-xl-/-Status-/-exclamation-triangle" fill="#F0AB00">
+                    <path d="M55.6811464,54.9998718 C59.5692673,54.9998718 62.0128612,50.7818528 60.0661228,47.4074788 L34.7600689,3.52969955 C32.8158025,0.159857423 27.9375754,0.153677628 25.9899101,3.52969955 L0.683135242,47.4074788 C-1.25979225,50.775364 1.17257499,54.9998718 5.06821466,54.9998718 L55.6811464,54.9998718 Z M32.9350725,36.437416 L27.8149065,36.437416 C27.1427508,36.437416 26.5878052,35.9119275 26.5512414,35.2408018 L25.7688794,20.897086 C25.7293287,20.172093 26.3064186,19.5624563 27.0324415,19.5624563 L33.7174345,19.5624563 C34.4434574,19.5624563 35.0206503,20.172093 34.9810996,20.897086 L34.1987376,35.2408018 C34.1621738,35.9119275 33.6072282,36.437416 32.9350725,36.437416 Z M30.3749895,48.0389509 C27.6955335,48.0389509 25.5234386,45.866856 25.5234386,43.1873999 C25.5234386,40.5079439 27.6955335,38.335849 30.3749895,38.335849 C33.0544455,38.335849 35.2265404,40.5079439 35.2265404,43.1873999 C35.2265404,45.866856 33.0544455,48.0389509 30.3749895,48.0389509 Z" id="exclamation-triangle"></path>
+                </g>
+            </g>
+        </svg>
         <span style="font-size: larger">&nbsp; Security Issues</span>
 
     </div>
@@ -154,19 +152,25 @@
                 <p style="font-size: larger">Dependencies with security issues in your stack.</p>
                 <p>Dependencies with high common vulnerabilities and exposures (CVE) score.</p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-info">
-                          <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#2b9af3">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Total Vulnerabilities: 0
                 </p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-warning">
-                        <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#f0ab00">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Vulnerable Dependencies: 0
                 </p>
             </div>

--- a/src/test/resources/__files/reports/report_forbidden.html
+++ b/src/test/resources/__files/reports/report_forbidden.html
@@ -18,6 +18,7 @@
         </g>
     </symbol>
 </svg>
+<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/html">
 <head>
 <style type="text/css">
@@ -121,14 +122,8 @@
     /*#snyk {background-color: lightgreen;}*/
 </style>    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="fonts.css"/>
     <!-- Include latest PatternFly CSS via CDN -->
-    <link
-            rel="stylesheet"
-            href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
-            crossorigin="anonymous"
-    />
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@2/patternfly.css" crossorigin />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
           integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <title>Dependency Analysis</title>
@@ -137,11 +132,14 @@
 
 <div class="card">
     <div class="card-header">
-        <span class="pf-c-icon">
-          <span class="pf-c-icon__content pf-m-warning">
-            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-          </span>
-        </span>
+        <svg width="31px" height="25px" viewBox="0 0 61 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="padding-bottom: 5px">
+            <title></title>
+            <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Icons-/-4.-Size-xl-/-Status-/-exclamation-triangle" fill="#F0AB00">
+                    <path d="M55.6811464,54.9998718 C59.5692673,54.9998718 62.0128612,50.7818528 60.0661228,47.4074788 L34.7600689,3.52969955 C32.8158025,0.159857423 27.9375754,0.153677628 25.9899101,3.52969955 L0.683135242,47.4074788 C-1.25979225,50.775364 1.17257499,54.9998718 5.06821466,54.9998718 L55.6811464,54.9998718 Z M32.9350725,36.437416 L27.8149065,36.437416 C27.1427508,36.437416 26.5878052,35.9119275 26.5512414,35.2408018 L25.7688794,20.897086 C25.7293287,20.172093 26.3064186,19.5624563 27.0324415,19.5624563 L33.7174345,19.5624563 C34.4434574,19.5624563 35.0206503,20.172093 34.9810996,20.897086 L34.1987376,35.2408018 C34.1621738,35.9119275 33.6072282,36.437416 32.9350725,36.437416 Z M30.3749895,48.0389509 C27.6955335,48.0389509 25.5234386,45.866856 25.5234386,43.1873999 C25.5234386,40.5079439 27.6955335,38.335849 30.3749895,38.335849 C33.0544455,38.335849 35.2265404,40.5079439 35.2265404,43.1873999 C35.2265404,45.866856 33.0544455,48.0389509 30.3749895,48.0389509 Z" id="exclamation-triangle"></path>
+                </g>
+            </g>
+        </svg>
         <span style="font-size: larger">&nbsp; Security Issues</span>
 
     </div>
@@ -154,19 +152,25 @@
                 <p style="font-size: larger">Dependencies with security issues in your stack.</p>
                 <p>Dependencies with high common vulnerabilities and exposures (CVE) score.</p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-info">
-                          <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#2b9af3">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Total Vulnerabilities: 0
                 </p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-warning">
-                        <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#f0ab00">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Vulnerable Dependencies: 0
                 </p>
             </div>

--- a/src/test/resources/__files/reports/report_unauthorized.html
+++ b/src/test/resources/__files/reports/report_unauthorized.html
@@ -18,6 +18,7 @@
         </g>
     </symbol>
 </svg>
+<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/html">
 <head>
 <style type="text/css">
@@ -121,14 +122,8 @@
     /*#snyk {background-color: lightgreen;}*/
 </style>    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="fonts.css"/>
     <!-- Include latest PatternFly CSS via CDN -->
-    <link
-            rel="stylesheet"
-            href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
-            crossorigin="anonymous"
-    />
-    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/@patternfly/patternfly@2/patternfly.css" crossorigin />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
           integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <title>Dependency Analysis</title>
@@ -137,11 +132,14 @@
 
 <div class="card">
     <div class="card-header">
-        <span class="pf-c-icon">
-          <span class="pf-c-icon__content pf-m-warning">
-            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-          </span>
-        </span>
+        <svg width="31px" height="25px" viewBox="0 0 61 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="padding-bottom: 5px">
+            <title></title>
+            <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Icons-/-4.-Size-xl-/-Status-/-exclamation-triangle" fill="#F0AB00">
+                    <path d="M55.6811464,54.9998718 C59.5692673,54.9998718 62.0128612,50.7818528 60.0661228,47.4074788 L34.7600689,3.52969955 C32.8158025,0.159857423 27.9375754,0.153677628 25.9899101,3.52969955 L0.683135242,47.4074788 C-1.25979225,50.775364 1.17257499,54.9998718 5.06821466,54.9998718 L55.6811464,54.9998718 Z M32.9350725,36.437416 L27.8149065,36.437416 C27.1427508,36.437416 26.5878052,35.9119275 26.5512414,35.2408018 L25.7688794,20.897086 C25.7293287,20.172093 26.3064186,19.5624563 27.0324415,19.5624563 L33.7174345,19.5624563 C34.4434574,19.5624563 35.0206503,20.172093 34.9810996,20.897086 L34.1987376,35.2408018 C34.1621738,35.9119275 33.6072282,36.437416 32.9350725,36.437416 Z M30.3749895,48.0389509 C27.6955335,48.0389509 25.5234386,45.866856 25.5234386,43.1873999 C25.5234386,40.5079439 27.6955335,38.335849 30.3749895,38.335849 C33.0544455,38.335849 35.2265404,40.5079439 35.2265404,43.1873999 C35.2265404,45.866856 33.0544455,48.0389509 30.3749895,48.0389509 Z" id="exclamation-triangle"></path>
+                </g>
+            </g>
+        </svg>
         <span style="font-size: larger">&nbsp; Security Issues</span>
 
     </div>
@@ -154,19 +152,25 @@
                 <p style="font-size: larger">Dependencies with security issues in your stack.</p>
                 <p>Dependencies with high common vulnerabilities and exposures (CVE) score.</p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-info">
-                          <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#2b9af3">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Total Vulnerabilities: 0
                 </p>
                 <p class="ml-5">
-                    <span class="pf-c-icon pf-m-sm">
-                      <span class="pf-c-icon__content pf-m-warning">
-                        <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
-                      </span>
-                    </span>
+                    <svg width="18px" height="18px" viewBox="0 0 48 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <title></title>
+                        <g id="Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                            <g id="Icons-/-4.-Size-xl-/-Status-/-pficon-security" fill="#f0ab00">
+                                <path d="M45.4306641,0 L1.81933594,0 C0.812109375,0 0,0.754101563 0,1.6875 L0,23.8412109 C0,40.5 20.4451172,54 23.6513672,54 C26.8576172,54 47.25,40.5 47.25,23.8464844 L47.25,1.6875 C47.25,0.754101563 46.4378906,0 45.4306641,0 Z M25.8767578,40.5 L21.3732422,40.5 C20.7509766,40.4894531 20.2605469,39.9462891 20.25,39.2712891 L20.25,34.9787109 C20.2605469,34.3037109 20.75625,33.7658203 21.3732422,33.75 L25.8767578,33.75 C26.4990234,33.7605469 26.9894531,34.3037109 27,34.9787109 L27,39.2712891 L27.0052734,39.2712891 C26.9894531,39.9462891 26.49375,40.4894531 25.8767578,40.5 Z M28.6822266,8.57988281 L27.2742188,27.1265625 C27.2003906,27.9966797 26.4726563,28.6875 25.5919922,28.6875 L21.6527344,28.6875 C20.7773438,28.6875 20.0443359,28.0125 19.9705078,27.1423828 L18.5677734,8.59570312 C18.4833984,7.60957031 19.2638672,6.76582031 20.25,6.76582031 L27,6.75 C27.9861328,6.75 28.7613281,7.59375 28.6822266,8.57988281 Z" id="pficon-security"></path>
+                            </g>
+                        </g>
+                    </svg>
                     Vulnerable Dependencies: 0
                 </p>
             </div>


### PR DESCRIPTION
Imported a new URL for patternFly CDN to fix the table. Replaced images with SVG for the icons to be displayed in the summary card. 