### PR TITLE
POC: Replace freemarker reports by standard UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,17 @@
       <artifactId>spdx-jackson-store</artifactId>
       <version>${spdx.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-qute</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.trustification</groupId>
+      <artifactId>crda-report-ui</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>

--- a/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
@@ -29,6 +29,7 @@ import org.apache.camel.builder.AggregationStrategies;
 import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 import org.apache.camel.component.micrometer.MicrometerConstants;
 import org.apache.camel.component.micrometer.routepolicy.MicrometerRoutePolicyFactory;
+import org.apache.camel.component.rest.RestConstants;
 
 import com.redhat.exhort.integration.Constants;
 import com.redhat.exhort.integration.ProviderAggregationStrategy;
@@ -98,7 +99,9 @@ public class ExhortIntegration extends EndpointRouteBuilder {
         .to(direct("findVulnerabilities"))
         .to(direct("recommendAllTrustedContent"))
         .to(direct("report"))
-        .process(this::cleanUpHeaders);
+        .process(this::cleanUpHeaders)
+
+        .setHeader(RestConstants.CONTENT_TYPE, constant("application/octet-stream"));
 
     from(direct("findVulnerabilities"))
         .routeId("findVulnerabilities")

--- a/src/main/resources/templates/data.js
+++ b/src/main/resources/templates/data.js
@@ -1,0 +1,2 @@
+// This file should contain all JSONs data discovered
+window["sbomb"]={params};

--- a/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
@@ -20,6 +20,7 @@ package com.redhat.exhort.integration;
 
 import static io.restassured.RestAssured.given;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
+import static org.apache.camel.model.rest.RestParamType.body;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringStartsWith.startsWithIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,10 +35,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
 import java.util.stream.Stream;
 
 import org.cyclonedx.CycloneDxMediaType;
@@ -452,11 +452,11 @@ public class AnalysisTest extends AbstractAnalysisTest {
     stubAllProviders();
     stubTCRequests();
 
-    String body =
+    byte[] body =
         given()
             .header(CONTENT_TYPE, CycloneDxMediaType.APPLICATION_CYCLONEDX_JSON)
             .body(loadSBOMFile(CYCLONEDX))
-            .header("Accept", MediaType.TEXT_HTML)
+            // .header("Accept", MediaType.APPLICATION_OCTET_STREAM)
             .header(Constants.SNYK_TOKEN_HEADER, OK_TOKEN)
             .header(Constants.OSS_INDEX_USER_HEADER, OK_USER)
             .header(Constants.OSS_INDEX_TOKEN_HEADER, OK_TOKEN)
@@ -465,12 +465,16 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .then()
             .assertThat()
             .statusCode(200)
-            .contentType(MediaType.TEXT_HTML)
             .extract()
             .body()
-            .asString();
+            .asByteArray();
 
-    assertHtml("reports/report_all_token.html", body);
+    try {
+      Files.write(Paths.get("/home/cferiavi/Downloads/crda.zip"), body);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    //    assertHtml("reports/report_all_token.html", RestParamType.body);
 
     verifySnykRequest(OK_TOKEN);
     verifyTCRequests();


### PR DESCRIPTION
This PR shows a Prove of Concept to show how to create a static report based on common UI standards.

## Motivation
- The current report is created using Fremarker and although useful might present difficulties while creating complex UIs where we need to include different JS dependencies.
- The current report is loading fonts and styles from online resources like `https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css` and `https://unpkg.com/@patternfly/patternfly/patternfly.css`. This might cause issues if the final user, who watches the report, is under a network whose proxies block certain outside resources.

## How this PR works?
- This PR delegates the responsibility of creating the UI (reports) to a pure UI repository https://github.com/carlosthe19916/crda-static-report
- This PR makes this repository responsible of only generating the data needed for the report and then send the data to the UI for it to be able to be rendered.

## How to make this prove of concept work?

- Clone and install the UI repository locally

```
git clone https://github.com/carlosthe19916/crda-static-report
cd crda-static-report
mvn install
```

- Clone the current repository and checkout this current PR
- Make sure you change this line https://github.com/RHEcosystemAppEng/exhort/compare/main...carlosthe19916:exhort:static-report?expand=1#diff-0c427d9df9df3782503566c6a134b0ab77fcd9084c6b04d8ea4ce2288f965003R473 because it is where the final report will be written.
- Execute the test `AnalysisTest#testHtmlWithToken`. Use your IDE or the following command:

```
mvn test -Dtest=AnalysisTest#testHtmlWithToken
```

- After the test of the previous command is finished there should be a `.zip` file created at https://github.com/RHEcosystemAppEng/exhort/compare/main...carlosthe19916:exhort:static-report?expand=1#diff-0c427d9df9df3782503566c6a134b0ab77fcd9084c6b04d8ea4ce2288f965003R473 . unzip the file and open the `index.html` file.


> Note: the code of this repository assumes you are working on Linux because there are some hardcoded paths only valid for Linux. The purpose of this PR is show something working, the code must be polished.

# Demo

https://youtu.be/ADn0ouf8GRg

# Consequences of this PR
-  The rest endpoint that generates the report no longer generates HTML files but ZIP files
- The zip file that is generated by this PR can be consumed by the IDE plugin, unzip the content and render it in the IDE

## Ideas
- This PR relies on https://github.com/carlosthe19916/crda-static-report to generate the UI but the UI repository can easily be added to the repository as a maven module. Otherwise, we can keep the UI repository independent and release it in maven central as any other maven library.
