### PR TITLE
chore: add pre and post action validations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,8 @@
 name: CI
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
-      - main
+      - '*'
   workflow_dispatch: # allow this workflow to be called by other workflows
 
 concurrency:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -89,7 +89,7 @@ jobs:
           cache: 'maven'
 
       - name: Build Package with Maven
-        run: mvn package -Pnative
+        run: mvn verify -Pnative
 
       - name: Build Image With buildah
         id: build-image

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -16,8 +16,8 @@ env:
   IMAGE_REGISTRY: quay.io/ecosystem-appeng
   IMAGE_NAME: exhort
   IMAGE_TAGS: latest
-  IMAGE_REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
-  IMAGE_REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+  IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
+  IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
   # 🖊️ EDIT to change Dockerfile.
   DOCKERFILE_PATH: ./src/main/docker/Dockerfile.native-micro
 
@@ -29,10 +29,50 @@ on:
       - '*'
 
 jobs:
-  build_and_push_image:
+  validate_workflow_requirements:
     runs-on: ubuntu-latest
 
     if: github.repository == 'RHEcosystemAppEng/exhort'
+
+    steps:
+      - name: Check For Required Secrets
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const secrets = {
+              OPENSHIFT_SERVER: `${{ env.OPENSHIFT_SERVER }}`,
+              OPENSHIFT_TOKEN: `${{ env.OPENSHIFT_TOKEN }}`,
+            };
+            
+            // if image registry is ghcr.io - no registry credentials required, otherwise get registry credentials
+            if (!`${{ env.IMAGE_REGISTRY }}`.startsWith("ghcr.io")) {
+              secrets["IMAGE_REGISTRY_USER"] = `${{ env.IMAGE_REGISTRY_USER }}`;
+              secrets["IMAGE_REGISTRY_PASSWORD"] = `${{ env.IMAGE_REGISTRY_PASSWORD }}`;
+            }
+
+            const missingSecrets = Object.entries(secrets).filter(([ name, value ]) => {
+              if (value.length === 0) {
+                core.error(`Secret "${name}" is not set`);
+                return true;
+              }
+              core.info(`✔️ Secret "${name}" is set`);
+              return false;
+            });
+
+            if (missingSecrets.length > 0) {
+              core.setFailed(`❌ At least one required secret is not set in the repository. \n` +
+                "You can add it using:\n" +
+                "GitHub UI: https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository \n" +
+                "GitHub CLI: https://cli.github.com/manual/gh_secret_set \n" +
+                "Also, refer to https://github.com/redhat-actions/oc-login#getting-started-with-the-action-or-see-example");
+            }
+            else {
+              core.info(`✅ All the required secrets are set`);
+            }
+  
+  build_and_push_image:
+    needs: validate_workflow_requirements
+    runs-on: ubuntu-latest
     
     outputs:
       digest: ${{ steps.push-to-registry.outputs.digest }}
@@ -92,3 +132,6 @@ jobs:
         run: |
           DEPLOYMENT_PATCH=$(printf '{"spec": {"template": {"spec": {"containers": [{"name": "%s", "image": "%s/%s@%s"}]}}}}' ${{ env.OPENSHIFT_CONTAINER_NAME }} ${{ env.IMAGE_REGISTRY }} ${{ env.IMAGE_NAME }} ${{ needs.build_and_push_image.outputs.digest }})
           oc patch deployment ${{ env.OPENSHIFT_DEPLOYMENT_NAME }} -p "${DEPLOYMENT_PATCH}"
+          
+      - name: Monitor Deployment Status
+        run: oc rollout status deployment/${{ env.OPENSHIFT_DEPLOYMENT_NAME }}


### PR DESCRIPTION
1. Added validation of workflow requirements job that checks if all required secret have been configure, prints feedback to log. 
2. Added deployment monitoring step to deploy to Openshift job that monitors the progress of the deployment update. It continuously checks the status of the deployment and waits for all the new pods to become ready and available to handle traffic. 
3. Changed `mvn package -Pnative` to run `mvn verify -Pnative` instead in order to include integration tests in the workflow as well as build. 
4. Removed trigger `on push` from CI workflow as integration tests will be done in CICD workflow.