### PR TITLE
fix: support cyclic dependencies

### DIFF
--- a/src/main/java/com/redhat/exhort/integration/backend/sbom/cyclonedx/CycloneDxParser.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/sbom/cyclonedx/CycloneDxParser.java
@@ -139,8 +139,11 @@ public class CycloneDxParser extends SbomParser {
     }
     deps.forEach(
         d -> {
-          builder.transitive.add(componentPurls.get(d.getRef()));
-          addDependencies(d.getRef(), indexedDeps, builder, componentPurls);
+          PackageRef tRef = componentPurls.get(d.getRef());
+          if (!builder.transitive.contains(tRef)) {
+            builder.transitive.add(tRef);
+            addDependencies(d.getRef(), indexedDeps, builder, componentPurls);
+          }
         });
   }
 }

--- a/src/main/java/com/redhat/exhort/integration/backend/sbom/spdx/SpdxParser.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/sbom/spdx/SpdxParser.java
@@ -103,6 +103,11 @@ public class SpdxParser extends SbomParser {
                         .filter(e -> !e.getKey().equals(k))
                         .noneMatch(e -> e.getValue().contains(k)))
             .collect(Collectors.toSet());
+    if (!links.isEmpty() && directDeps.isEmpty()) {
+      throw new SpdxProcessingException(
+          "Unable to calculate direct dependencies due to a cyclic relationship");
+    }
+
     Map<String, Set<String>> flatDepTree = new HashMap<>();
     directDeps.stream()
         .forEach(

--- a/src/main/java/com/redhat/exhort/model/DependencyTree.java
+++ b/src/main/java/com/redhat/exhort/model/DependencyTree.java
@@ -18,6 +18,7 @@
 
 package com.redhat.exhort.model;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -55,10 +56,13 @@ public record DependencyTree(PackageRef root, Map<PackageRef, DirectDependency> 
   }
 
   public int transitiveCount() {
-    return dependencies.values().stream()
-        .map(d -> d.transitive().size())
-        .reduce(Integer::sum)
-        .orElse(0);
+    return Long.valueOf(
+            dependencies.values().stream()
+                .map(d -> d.transitive())
+                .flatMap(Collection::stream)
+                .distinct()
+                .count())
+        .intValue();
   }
 
   public int count() {

--- a/src/test/java/com/redhat/exhort/integration/report/ReportTransformerTest.java
+++ b/src/test/java/com/redhat/exhort/integration/report/ReportTransformerTest.java
@@ -107,7 +107,7 @@ public class ReportTransformerTest {
     assertEquals(1, report.getDependencies().get(1).getTransitive().size());
 
     assertEquals(2, report.getSummary().getDependencies().getScanned());
-    assertEquals(4, report.getSummary().getDependencies().getTransitive());
+    assertEquals(3, report.getSummary().getDependencies().getTransitive());
 
     assertEquals(2, report.getSummary().getVulnerabilities().getTotal());
   }

--- a/src/test/resources/cyclonedx/cyclic-sbom.json
+++ b/src/test/resources/cyclonedx/cyclic-sbom.json
@@ -1,0 +1,127 @@
+{
+    "bomFormat" : "CycloneDX",
+    "specVersion" : "1.4",
+    "version" : 1,
+    "metadata" : {
+      "component" : {
+        "name" : "postgresql-orm-quarkus",
+        "purl" : "pkg:maven/org.acme.dbaas/postgresql-orm-quarkus@1.0.0-SNAPSHOT?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/org.acme.dbaas/postgresql-orm-quarkus@1.0.0-SNAPSHOT?type=jar"
+      }
+    },
+    "components" : [
+      {
+        "name" : "quarkus-hibernate-orm",
+        "purl" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar"
+      },
+      {
+        "name" : "quarkus-core",
+        "purl" : "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar"
+      },
+      {
+        "name" : "jakarta.enterprise.cdi-api",
+        "purl" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+      },
+      {
+        "name" : "jakarta.el-api",
+        "purl" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar"
+      },
+      {
+        "name" : "quarkus-jdbc-postgresql",
+        "purl" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar"
+      },
+      {
+        "name" : "postgresql",
+        "purl" : "pkg:maven/org.postgresql/postgresql@42.5.0?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/org.postgresql/postgresql@42.5.0?type=jar"
+      },
+      {
+        "name" : "jackson-databind",
+        "purl" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1?type=jar"
+      },
+      {
+        "name" : "quarkus-narayana-jta",
+        "purl" : "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar"
+      },
+      {
+        "name" : "jakarta.interceptor-api",
+        "purl" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+        "type" : "library",
+        "bom-ref" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar"
+      }
+    ],
+    "dependencies" : [
+      {
+        "ref" : "pkg:maven/org.acme.dbaas/postgresql-orm-quarkus@1.0.0-SNAPSHOT?type=jar",
+        "dependsOn" : [
+          "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar",
+          "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar"
+        ]
+      },
+      {
+        "ref" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar",
+        "dependsOn" : [
+          "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar",
+          "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar",
+          "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar"
+        ]
+      },
+      {
+        "ref" : "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar",
+        "dependsOn" : [
+          "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1?type=jar",
+          "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar"
+        ]
+      },
+      {
+        "ref" : "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar",
+        "dependsOn" : [ ]
+      },
+      {
+        "ref" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1?type=jar",
+        "dependsOn" : [ ]
+      },
+      {
+        "ref" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+        "dependsOn" : [
+          "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+          "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar"
+        ]
+      },
+      {
+        "ref" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar",
+        "dependsOn" : [
+           "pkg:maven/org.postgresql/postgresql@42.5.0?type=jar",
+           "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar"
+        ]
+      },
+      {
+        "ref" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+        "dependsOn" : [ ]
+      },
+      {
+        "ref" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+        "dependsOn" : [ ]
+      },
+      {
+        "ref" : "pkg:maven/org.postgresql/postgresql@42.5.0?type=jar",
+        "dependsOn" : [ ]
+      }
+    ]
+  }

--- a/src/test/resources/spdx/cyclic-sbom.json
+++ b/src/test/resources/spdx/cyclic-sbom.json
@@ -1,0 +1,255 @@
+{
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.3",
+  "creationInfo" : {
+    "comment" : "Converted from CycloneDX spec version 1.4",
+    "created" : "2023-07-26T09:11:18Z",
+    "creators" : [ "Tool: CycloneToSpdx-0.1.4" ],
+    "licenseListVersion" : "3.21"
+  },
+  "name" : "postgresql-orm-quarkus",
+  "dataLicense" : "CC0-1.0",
+  "documentNamespace" : "https://cyclonedx/fc12be53-d648-445d-8df3-9fe49c1924ac_1",
+  "packages" : [ {
+    "SPDXID" : "SPDXRef-pkg-maven-io.quarkus-quarkus-jdbc-postgresql-2.13.5.Final-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "quarkus-jdbc-postgresql",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-io.quarkus-quarkus-hibernate-orm-2.13.5.Final-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "quarkus-hibernate-orm",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-org.acme.dbaas-postgresql-orm-quarkus-1.0.0-SNAPSHOT-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/org.acme.dbaas/postgresql-orm-quarkus@1.0.0-SNAPSHOT?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "postgresql-orm-quarkus",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-com.fasterxml.jackson.core-jackson-databind-2.13.1-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "jackson-databind",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-org.postgresql-postgresql-42.5.0-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/org.postgresql/postgresql@42.5.0?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "postgresql",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-jakarta.el-jakarta.el-api-3.0.3-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "jakarta.el-api",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-io.quarkus-quarkus-narayana-jta-2.13.5.Final-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "quarkus-narayana-jta",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-io.quarkus-quarkus-core-2.13.5.Final-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "quarkus-core",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-jakarta.interceptor-jakarta.interceptor-api-1.2.5-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "jakarta.interceptor-api",
+    "primaryPackagePurpose" : "LIBRARY"
+  }, {
+    "SPDXID" : "SPDXRef-pkg-maven-jakarta.enterprise-jakarta.enterprise.cdi-api-2.0.2-type-jar",
+    "annotations" : [ {
+      "annotationDate" : "2023-07-26T09:11:19Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Tool: CycloneToSpdx",
+      "comment" : "MISSING_CDX_PROPERTY:componentType=\"LIBRARY\""
+    } ],
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE-MANAGER",
+      "referenceLocator" : "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "jakarta.enterprise.cdi-api",
+    "primaryPackagePurpose" : "LIBRARY"
+  } ],
+  "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relationshipType" : "DESCRIBES",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-org.acme.dbaas-postgresql-orm-quarkus-1.0.0-SNAPSHOT-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-io.quarkus-quarkus-jdbc-postgresql-2.13.5.Final-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-org.postgresql-postgresql-42.5.0-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-io.quarkus-quarkus-jdbc-postgresql-2.13.5.Final-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-io.quarkus-quarkus-hibernate-orm-2.13.5.Final-type-jar"
+  },{
+    "spdxElementId" : "SPDXRef-pkg-maven-io.quarkus-quarkus-hibernate-orm-2.13.5.Final-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-io.quarkus-quarkus-narayana-jta-2.13.5.Final-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-io.quarkus-quarkus-hibernate-orm-2.13.5.Final-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-io.quarkus-quarkus-core-2.13.5.Final-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-io.quarkus-quarkus-hibernate-orm-2.13.5.Final-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-io.quarkus-quarkus-jdbc-postgresql-2.13.5.Final-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-io.quarkus-quarkus-core-2.13.5.Final-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-jakarta.enterprise-jakarta.enterprise.cdi-api-2.0.2-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-io.quarkus-quarkus-core-2.13.5.Final-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-com.fasterxml.jackson.core-jackson-databind-2.13.1-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-jakarta.enterprise-jakarta.enterprise.cdi-api-2.0.2-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-jakarta.interceptor-jakarta.interceptor-api-1.2.5-type-jar"
+  }, {
+    "spdxElementId" : "SPDXRef-pkg-maven-jakarta.enterprise-jakarta.enterprise.cdi-api-2.0.2-type-jar",
+    "relationshipType" : "DEPENDS_ON",
+    "relatedSpdxElement" : "SPDXRef-pkg-maven-jakarta.el-jakarta.el-api-3.0.3-type-jar"
+  } ]
+}


### PR DESCRIPTION
fix #153 

For CycloneDX it's just a matter of stopping the recursive function when the cyclic dependency is detected.
However for SPDX, the root node does not point to the direct dependencies so it is not possible to draw a reliable graph in that case as there are multiple alternatives. In that case it will be better to throw a validation error.