### PR TITLE
feat: Generate and add ex-request-id response header

### DIFF
--- a/src/main/java/com/redhat/exhort/integration/Constants.java
+++ b/src/main/java/com/redhat/exhort/integration/Constants.java
@@ -45,7 +45,7 @@ public final class Constants {
   public static final String RHDA_SOURCE_HEADER = "rhda-source";
   public static final String RHDA_OPERATION_TYPE_HEADER = "rhda-operation-type";
   public static final String USER_AGENT_HEADER = "User-Agent";
-
+  public static final String EXHORT_REQUEST_ID_HEADER = "ex-request-id";
   public static final MediaType MULTIPART_MIXED_TYPE = new MediaType("multipart", "mixed");
   public static final String MULTIPART_MIXED = MULTIPART_MIXED_TYPE.toString();
   public static final String SPDX_MEDIATYPE_JSON = "application/vnd.spdx+json";
@@ -73,6 +73,7 @@ public final class Constants {
   public static final String API_VERSION_V4 = "v4";
   public static final String API_VERSION_V3 = "v3";
 
+  public static final String EXHORT_REQUEST_ID_PROPERTY = "exRequestId";
   public static final String SNYK_DEP_GRAPH_API_PATH = "/test/dep-graph";
   public static final String SNYK_TOKEN_API_PATH = "/user/me";
   public static final String OSS_INDEX_AUTH_COMPONENT_API_PATH = "/authorized/component-report";

--- a/src/main/java/com/redhat/exhort/integration/Constants.java
+++ b/src/main/java/com/redhat/exhort/integration/Constants.java
@@ -73,7 +73,6 @@ public final class Constants {
   public static final String API_VERSION_V4 = "v4";
   public static final String API_VERSION_V3 = "v3";
 
-  public static final String EXHORT_REQUEST_ID_PROPERTY = "exRequestId";
   public static final String SNYK_DEP_GRAPH_API_PATH = "/test/dep-graph";
   public static final String SNYK_TOKEN_API_PATH = "/user/me";
   public static final String OSS_INDEX_AUTH_COMPONENT_API_PATH = "/authorized/component-report";

--- a/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
@@ -18,6 +18,12 @@
 
 package com.redhat.exhort.integration.backend;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
 import org.apache.camel.Header;
 import org.jboss.resteasy.reactive.common.util.MediaTypeHelper;
 
@@ -46,5 +52,34 @@ public class BackendUtils {
           Status.UNSUPPORTED_MEDIA_TYPE);
     }
     return match.toString();
+  }
+
+  public String generateRequestId(@Header(Constants.RHDA_TOKEN_HEADER) String rhdaToken) {
+    byte[] requestId;
+    try {
+      MessageDigest digestMaker = MessageDigest.getInstance("SHA-256");
+      String tsOfNow = LocalDateTime.now().toString();
+      var token = rhdaToken;
+      if (Objects.isNull(rhdaToken) || rhdaToken.trim().equals("")) {
+        token = Double.valueOf(Math.random()).toString();
+      }
+      byte[] inputForSha256 = new String(token + tsOfNow).getBytes(StandardCharsets.UTF_8);
+      requestId = digestMaker.digest(inputForSha256);
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+    return bytesToHex(requestId);
+  }
+
+  private static String bytesToHex(byte[] hash) {
+    StringBuilder hexString = new StringBuilder(2 * hash.length);
+    for (int i = 0; i < hash.length; i++) {
+      String hex = Integer.toHexString(0xff & hash[i]);
+      if (hex.length() == 1) {
+        hexString.append('0');
+      }
+      hexString.append(hex);
+    }
+    return hexString.toString();
   }
 }

--- a/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
@@ -21,6 +21,7 @@ package com.redhat.exhort.integration.backend;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -36,6 +37,12 @@ import jakarta.ws.rs.core.Response.Status;
 
 @RegisterForReflection
 public class BackendUtils {
+
+  public void setClock(Clock clock) {
+    this.clock = clock;
+  }
+
+  private Clock clock;
 
   public String getResponseMediaType(@Header(Constants.ACCEPT_HEADER) String acceptHeader) {
     if (acceptHeader == null || acceptHeader.isBlank()) {
@@ -58,7 +65,12 @@ public class BackendUtils {
     byte[] requestId;
     try {
       MessageDigest digestMaker = MessageDigest.getInstance("SHA-256");
-      String tsOfNow = LocalDateTime.now().toString();
+      String tsOfNow;
+      if (Objects.isNull(this.clock)) {
+        tsOfNow = LocalDateTime.now(Clock.systemDefaultZone()).toString();
+      } else {
+        tsOfNow = LocalDateTime.now(this.clock).toString();
+      }
       var token = rhdaToken;
       if (Objects.isNull(rhdaToken) || rhdaToken.trim().equals("")) {
         token = Double.valueOf(Math.random()).toString();

--- a/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
@@ -38,7 +38,11 @@ import jakarta.ws.rs.core.Response.Status;
 @RegisterForReflection
 public class BackendUtils {
 
-  public void setClock(Clock clock) {
+  public BackendUtils() {
+    this.clock = Clock.systemDefaultZone();
+  }
+
+  public BackendUtils(Clock clock) {
     this.clock = clock;
   }
 
@@ -66,11 +70,7 @@ public class BackendUtils {
     try {
       MessageDigest digestMaker = MessageDigest.getInstance("SHA-256");
       String tsOfNow;
-      if (Objects.isNull(this.clock)) {
-        tsOfNow = LocalDateTime.now(Clock.systemDefaultZone()).toString();
-      } else {
-        tsOfNow = LocalDateTime.now(this.clock).toString();
-      }
+      tsOfNow = LocalDateTime.now(this.clock).toString();
       var token = rhdaToken;
       if (Objects.isNull(rhdaToken) || rhdaToken.trim().equals("")) {
         token = Double.valueOf(Math.random()).toString();

--- a/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
@@ -86,6 +86,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .process(monitoringProcessor::processClientException)
       .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(422))
       .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
       .handled(true)
       .setBody().simple("${exception.message}");
 
@@ -95,6 +96,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .process(monitoringProcessor::processClientException)
       .setHeader(Exchange.HTTP_RESPONSE_CODE, simple("${exception.getResponse().getStatus()}"))
       .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
       .handled(true)
       .setBody().simple("${exception.message}");
 
@@ -120,10 +122,11 @@ public class ExhortIntegration extends EndpointRouteBuilder {
     from(direct("v4analysis"))
       .routeId("v4Analysis")
       .setProperty(Constants.API_VERSION_PROPERTY, constant(Constants.API_VERSION_V4))
-      .to(direct("analysis"));     
+      .to(direct("analysis"));
 
     from(direct("analysis"))
       .routeId("dependencyAnalysis")
+      .setProperty(Constants.EXHORT_REQUEST_ID_PROPERTY, method(BackendUtils.class,"generateRequestId"))
       .to(seda("analyticsIdentify"))
       .setProperty(PROVIDERS_PARAM, method(vulnerabilityProvider, "getProvidersFromQueryParam"))
       .setProperty(REQUEST_CONTENT_PROPERTY, method(BackendUtils.class, "getResponseMediaType"))
@@ -134,6 +137,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .transform().method(ProviderAggregationStrategy.class, "toReport")
       .to(direct("report"))
       .to(seda("analyticsTrackAnalysis"))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
       .process(this::cleanUpHeaders);
 
     from(direct("findVulnerabilities"))
@@ -144,6 +148,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
 
     from(direct("validateToken"))
       .routeId("validateToken")
+      .setProperty(Constants.EXHORT_REQUEST_ID_PROPERTY, method(BackendUtils.class,"generateRequestId"))
       .to(seda("analyticsIdentify"))
       .choice()
         .when(header(Constants.SNYK_TOKEN_HEADER).isNotNull())
@@ -159,6 +164,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .end()
       .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
       .to(seda("analyticsTrackToken"))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
       .process(this::cleanUpHeaders);
 
     from(seda("analyticsIdentify"))
@@ -176,6 +182,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
 
     from(seda("processFailedRequests"))
       .routeId("processFailedRequests")
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
       .process(monitoringProcessor::processServerError);
 
     from(direct("processInternalError"))

--- a/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
@@ -86,7 +86,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .process(monitoringProcessor::processClientException)
       .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(422))
       .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
-      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
       .handled(true)
       .setBody().simple("${exception.message}");
 
@@ -96,7 +96,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .process(monitoringProcessor::processClientException)
       .setHeader(Exchange.HTTP_RESPONSE_CODE, simple("${exception.getResponse().getStatus()}"))
       .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
-      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
       .handled(true)
       .setBody().simple("${exception.message}");
 
@@ -126,7 +126,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
 
     from(direct("analysis"))
       .routeId("dependencyAnalysis")
-      .setProperty(Constants.EXHORT_REQUEST_ID_PROPERTY, method(BackendUtils.class,"generateRequestId"))
+      .setProperty(Constants.EXHORT_REQUEST_ID_HEADER, method(BackendUtils.class,"generateRequestId"))
       .to(seda("analyticsIdentify"))
       .setProperty(PROVIDERS_PARAM, method(vulnerabilityProvider, "getProvidersFromQueryParam"))
       .setProperty(REQUEST_CONTENT_PROPERTY, method(BackendUtils.class, "getResponseMediaType"))
@@ -137,7 +137,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .transform().method(ProviderAggregationStrategy.class, "toReport")
       .to(direct("report"))
       .to(seda("analyticsTrackAnalysis"))
-      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
       .process(this::cleanUpHeaders);
 
     from(direct("findVulnerabilities"))
@@ -148,7 +148,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
 
     from(direct("validateToken"))
       .routeId("validateToken")
-      .setProperty(Constants.EXHORT_REQUEST_ID_PROPERTY, method(BackendUtils.class,"generateRequestId"))
+      .setProperty(Constants.EXHORT_REQUEST_ID_HEADER, method(BackendUtils.class,"generateRequestId"))
       .to(seda("analyticsIdentify"))
       .choice()
         .when(header(Constants.SNYK_TOKEN_HEADER).isNotNull())
@@ -164,7 +164,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
       .end()
       .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
       .to(seda("analyticsTrackToken"))
-      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
       .process(this::cleanUpHeaders);
 
     from(seda("analyticsIdentify"))
@@ -182,7 +182,7 @@ public class ExhortIntegration extends EndpointRouteBuilder {
 
     from(seda("processFailedRequests"))
       .routeId("processFailedRequests")
-      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_PROPERTY))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
       .process(monitoringProcessor::processServerError);
 
     from(direct("processInternalError"))

--- a/src/main/java/com/redhat/exhort/monitoring/MonitoringProcessor.java
+++ b/src/main/java/com/redhat/exhort/monitoring/MonitoringProcessor.java
@@ -47,7 +47,7 @@ public class MonitoringProcessor {
   };
 
   private static final String[] LOGGED_PROPERTIES = {
-    Exchange.FAILURE_ENDPOINT, Exchange.FAILURE_ROUTE_ID, Constants.EXHORT_REQUEST_ID_PROPERTY
+    Exchange.FAILURE_ENDPOINT, Exchange.FAILURE_ROUTE_ID, Constants.EXHORT_REQUEST_ID_HEADER
   };
 
   @Inject MonitoringClient client;
@@ -59,8 +59,8 @@ public class MonitoringProcessor {
             .collect(Collectors.toMap(h -> h, h -> exchange.getIn().getHeader(h, String.class)));
     var context = exchange.getProperty(MONITORING_CONTEXT, MonitoringContext.class);
     metadata.put(
-        Constants.EXHORT_REQUEST_ID_PROPERTY,
-        exchange.getProperty(Constants.EXHORT_REQUEST_ID_PROPERTY, String.class));
+        Constants.EXHORT_REQUEST_ID_HEADER,
+        exchange.getProperty(Constants.EXHORT_REQUEST_ID_HEADER, String.class));
     if (context == null) {
       context =
           new MonitoringContext(

--- a/src/main/java/com/redhat/exhort/monitoring/MonitoringProcessor.java
+++ b/src/main/java/com/redhat/exhort/monitoring/MonitoringProcessor.java
@@ -47,7 +47,7 @@ public class MonitoringProcessor {
   };
 
   private static final String[] LOGGED_PROPERTIES = {
-    Exchange.FAILURE_ENDPOINT, Exchange.FAILURE_ROUTE_ID
+    Exchange.FAILURE_ENDPOINT, Exchange.FAILURE_ROUTE_ID, Constants.EXHORT_REQUEST_ID_PROPERTY
   };
 
   @Inject MonitoringClient client;
@@ -58,6 +58,9 @@ public class MonitoringProcessor {
             .filter(e -> exchange.getIn().getHeaders().containsKey(e))
             .collect(Collectors.toMap(h -> h, h -> exchange.getIn().getHeader(h, String.class)));
     var context = exchange.getProperty(MONITORING_CONTEXT, MonitoringContext.class);
+    metadata.put(
+        Constants.EXHORT_REQUEST_ID_PROPERTY,
+        exchange.getProperty(Constants.EXHORT_REQUEST_ID_PROPERTY, String.class));
     if (context == null) {
       context =
           new MonitoringContext(
@@ -104,6 +107,7 @@ public class MonitoringProcessor {
     context.tags().put(ERROR_TYPE_TAG, errorType);
     Stream.of(LOGGED_PROPERTIES)
         .forEach(p -> context.metadata().put(p, exchange.getProperty(p, String.class)));
+
     var exception = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Exception.class);
     client.reportException(exception, context);
   }

--- a/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
@@ -71,6 +71,8 @@ public abstract class AbstractAnalysisTest {
 
   static final String WIREMOCK_URL_TEMPLATE = "__WIREMOCK_URL__";
 
+  static final String regexMatcherRequestId = "[a-f0-9]{64}";
+
   @InjectWireMock WireMockServer server;
 
   static {

--- a/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractAnalysisTest {
 
   static final String WIREMOCK_URL_TEMPLATE = "__WIREMOCK_URL__";
 
-  static final String regexMatcherRequestId = "[a-f0-9]{64}";
+  static final String REGEX_MATCHER_REQUEST_ID = "[a-f0-9]{64}";
 
   @InjectWireMock WireMockServer server;
 

--- a/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
@@ -80,7 +80,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
         .contentType(MediaType.TEXT_PLAIN)
         .header(
             Constants.EXHORT_REQUEST_ID_HEADER,
-            MatchesPattern.matchesPattern(regexMatcherRequestId))
+            MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
         .body(equalTo("Unsupported providers: [unknown]"));
 
     verifyNoInteractions();
@@ -100,7 +100,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .statusCode(200)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .contentType(MediaType.APPLICATION_JSON)
             .extract()
             .body()
@@ -132,7 +132,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .statusCode(200)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .contentType(MediaType.APPLICATION_JSON)
             .extract()
             .body()
@@ -173,7 +173,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .statusCode(200)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -241,7 +241,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .statusCode(200)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .contentType(MediaType.APPLICATION_JSON)
             .extract()
             .body()
@@ -270,7 +270,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .contentType(MediaType.APPLICATION_JSON)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asPrettyString();
@@ -297,7 +297,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .contentType(MediaType.APPLICATION_JSON)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -332,7 +332,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .contentType(MediaType.APPLICATION_JSON)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -367,7 +367,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .contentType(MediaType.APPLICATION_JSON)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -403,7 +403,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .contentType(MediaType.APPLICATION_JSON)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -440,7 +440,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .contentType(MediaType.APPLICATION_JSON)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -496,7 +496,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
         .assertThat()
         .header(
             Constants.EXHORT_REQUEST_ID_HEADER,
-            MatchesPattern.matchesPattern(regexMatcherRequestId))
+            MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
         .statusCode(415)
         .contentType(MediaType.TEXT_PLAIN);
 

--- a/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.cyclonedx.CycloneDxMediaType;
+import org.hamcrest.text.MatchesPattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -77,6 +78,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
         .assertThat()
         .statusCode(422)
         .contentType(MediaType.TEXT_PLAIN)
+        .header(
+            Constants.EXHORT_REQUEST_ID_HEADER,
+            MatchesPattern.matchesPattern(regexMatcherRequestId))
         .body(equalTo("Unsupported providers: [unknown]"));
 
     verifyNoInteractions();
@@ -94,6 +98,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .then()
             .assertThat()
             .statusCode(200)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .contentType(MediaType.APPLICATION_JSON)
             .extract()
             .body()
@@ -123,6 +130,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .then()
             .assertThat()
             .statusCode(200)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .contentType(MediaType.APPLICATION_JSON)
             .extract()
             .body()
@@ -161,6 +171,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .then()
             .assertThat()
             .statusCode(200)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -226,6 +239,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .then()
             .assertThat()
             .statusCode(200)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .contentType(MediaType.APPLICATION_JSON)
             .extract()
             .body()
@@ -252,6 +268,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asPrettyString();
@@ -276,6 +295,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -308,6 +330,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -340,6 +365,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -373,6 +401,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -407,6 +438,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.APPLICATION_JSON)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .as(AnalysisReport.class);
@@ -460,6 +494,9 @@ public class AnalysisTest extends AbstractAnalysisTest {
         .post("/api/v4/analysis")
         .then()
         .assertThat()
+        .header(
+            Constants.EXHORT_REQUEST_ID_HEADER,
+            MatchesPattern.matchesPattern(regexMatcherRequestId))
         .statusCode(415)
         .contentType(MediaType.TEXT_PLAIN);
 

--- a/src/test/java/com/redhat/exhort/integration/HtmlReportTest.java
+++ b/src/test/java/com/redhat/exhort/integration/HtmlReportTest.java
@@ -79,7 +79,7 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_HTML)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();
@@ -154,7 +154,7 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_HTML)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();
@@ -208,7 +208,7 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_HTML)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();
@@ -248,7 +248,7 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_HTML)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();
@@ -287,7 +287,7 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .assertThat()
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .statusCode(200)
             .contentType(MediaType.TEXT_HTML)
             .extract()

--- a/src/test/java/com/redhat/exhort/integration/HtmlReportTest.java
+++ b/src/test/java/com/redhat/exhort/integration/HtmlReportTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.cyclonedx.CycloneDxMediaType;
+import org.hamcrest.text.MatchesPattern;
 import org.junit.jupiter.api.Test;
 
 import com.gargoylesoftware.htmlunit.BrowserVersion;
@@ -76,6 +77,9 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.TEXT_HTML)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();
@@ -148,6 +152,9 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.TEXT_HTML)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();
@@ -199,6 +206,9 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.TEXT_HTML)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();
@@ -236,6 +246,9 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(200)
             .contentType(MediaType.TEXT_HTML)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();
@@ -272,6 +285,9 @@ public class HtmlReportTest extends AbstractAnalysisTest {
             .post("/api/v4/analysis")
             .then()
             .assertThat()
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .statusCode(200)
             .contentType(MediaType.TEXT_HTML)
             .extract()

--- a/src/test/java/com/redhat/exhort/integration/TokenValidationTest.java
+++ b/src/test/java/com/redhat/exhort/integration/TokenValidationTest.java
@@ -49,7 +49,7 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .statusCode(400)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .contentType(MediaType.TEXT_PLAIN)
             .extract()
             .body()
@@ -76,7 +76,7 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_PLAIN)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();
@@ -114,7 +114,7 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_PLAIN)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();
@@ -152,7 +152,7 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_PLAIN)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();
@@ -190,7 +190,7 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .contentType(MediaType.TEXT_PLAIN)
             .header(
                 Constants.EXHORT_REQUEST_ID_HEADER,
-                MatchesPattern.matchesPattern(regexMatcherRequestId))
+                MatchesPattern.matchesPattern(REGEX_MATCHER_REQUEST_ID))
             .extract()
             .body()
             .asString();

--- a/src/test/java/com/redhat/exhort/integration/TokenValidationTest.java
+++ b/src/test/java/com/redhat/exhort/integration/TokenValidationTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.hamcrest.text.MatchesPattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -46,6 +47,9 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .then()
             .assertThat()
             .statusCode(400)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .contentType(MediaType.TEXT_PLAIN)
             .extract()
             .body()
@@ -70,6 +74,9 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
             .contentType(MediaType.TEXT_PLAIN)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();
@@ -105,6 +112,9 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(Response.Status.OK.getStatusCode())
             .contentType(MediaType.TEXT_PLAIN)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();
@@ -140,6 +150,9 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(Response.Status.UNAUTHORIZED.getStatusCode())
             .contentType(MediaType.TEXT_PLAIN)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();
@@ -175,6 +188,9 @@ public class TokenValidationTest extends AbstractAnalysisTest {
             .assertThat()
             .statusCode(Response.Status.TOO_MANY_REQUESTS.getStatusCode())
             .contentType(MediaType.TEXT_PLAIN)
+            .header(
+                Constants.EXHORT_REQUEST_ID_HEADER,
+                MatchesPattern.matchesPattern(regexMatcherRequestId))
             .extract()
             .body()
             .asString();

--- a/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
@@ -92,11 +92,8 @@ class BackendUtilsTest {
     String randomUUID2 = UUID.randomUUID().toString();
     AtomicReference<String> reqId = new AtomicReference();
     AtomicReference<String> reqId2 = new AtomicReference();
-    ;
-    Thread thread =
-        new Thread(() -> reqId.set(this.backendUtilsFakeTimer.generateRequestId(randomUUID)));
-    Thread thread2 =
-        new Thread(() -> reqId2.set(this.backendUtilsFakeTimer.generateRequestId(randomUUID2)));
+    Thread thread = createThread(reqId, randomUUID);
+    Thread thread2 = createThread(reqId2, randomUUID2);
     thread.start();
     thread2.start();
     thread.join();
@@ -111,10 +108,8 @@ class BackendUtilsTest {
 
     AtomicReference<String> reqId = new AtomicReference();
     AtomicReference<String> reqId2 = new AtomicReference();
-    Thread thread =
-        new Thread(() -> reqId.set(this.backendUtilsFakeTimer.generateRequestId(randomUUID)));
-    Thread thread2 =
-        new Thread(() -> reqId2.set(this.backendUtilsFakeTimer.generateRequestId(randomUUID)));
+    Thread thread = createThread(reqId, randomUUID);
+    Thread thread2 = createThread(reqId2, randomUUID);
     thread.start();
     thread2.start();
     thread.join();
@@ -128,9 +123,8 @@ class BackendUtilsTest {
 
     AtomicReference<String> reqId = new AtomicReference();
     AtomicReference<String> reqId2 = new AtomicReference();
-    Thread thread = new Thread(() -> reqId.set(this.backendUtilsFakeTimer.generateRequestId(null)));
-    Thread thread2 =
-        new Thread(() -> reqId2.set(this.backendUtilsFakeTimer.generateRequestId(null)));
+    Thread thread = createThread(reqId, null);
+    Thread thread2 = createThread(reqId2, null);
     thread.start();
     thread2.start();
     thread.join();
@@ -160,5 +154,9 @@ class BackendUtilsTest {
     CompletableFuture.allOf(futuresReqIds.toArray(new CompletableFuture[0]))
         .get(5, TimeUnit.SECONDS);
     assertEquals(numberOfRequests, results.size());
+  }
+
+  private Thread createThread(AtomicReference<String> reqId, String rhdaToken) {
+    return new Thread(() -> reqId.set(this.backendUtilsFakeTimer.generateRequestId(rhdaToken)));
   }
 }

--- a/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
@@ -126,8 +126,6 @@ class BackendUtilsTest {
   void checkGeneratedWithSameTimeWithNullRHDATokenAndTheyShouldBeDifferent()
       throws InterruptedException {
 
-    String randomUUID = UUID.randomUUID().toString();
-
     AtomicReference<String> reqId = new AtomicReference();
     AtomicReference<String> reqId2 = new AtomicReference();
     Thread thread = new Thread(() -> reqId.set(this.backendUtilsFakeTimer.generateRequestId(null)));

--- a/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
@@ -53,8 +53,8 @@ class BackendUtilsTest {
     return Arrays.stream(ArrayUtils.toObject(requestId.getBytes(StandardCharsets.UTF_8)))
             .filter(
                 t -> // character is hexadecimal digit a-f
-                    (t.shortValue() >= 97 && t.shortValue() <= 102)
-                            // or char is one of 0-9 digits.
+                (t.shortValue() >= 97 && t.shortValue() <= 102)
+                        // or char is one of 0-9 digits.
                         || (t.shortValue() >= 48 && (t.shortValue() <= 57)))
             .collect(Collectors.toList())
             .size()

--- a/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
@@ -35,7 +35,7 @@ class BackendUtilsTest {
 
   private BackendUtils backendUtils;
   private BackendUtils backendUtilsFakeTimer;
-  private int numberOfRequests;
+  private static final int numberOfRequests = 10000;
 
   @BeforeEach
   void setUp() {
@@ -143,7 +143,6 @@ class BackendUtilsTest {
       throws InterruptedException, ExecutionException, TimeoutException {
     Executor executor = Executors.newCachedThreadPool();
     List<CompletableFuture<String>> futuresReqIds = new ArrayList<>();
-    numberOfRequests = 10000;
     Vector<String> results = new Vector<>();
     for (int i = 0; i < numberOfRequests; i++) {
       futuresReqIds.add(

--- a/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
@@ -137,7 +137,7 @@ class BackendUtilsTest {
       throws InterruptedException, ExecutionException, TimeoutException {
     Executor executor = Executors.newCachedThreadPool();
     List<CompletableFuture<String>> futuresReqIds = new ArrayList<>();
-    Vector<String> results = new Vector<>();
+    Set<String> results = ConcurrentHashMap.newKeySet();
     for (int i = 0; i < numberOfRequests; i++) {
       futuresReqIds.add(
           CompletableFuture.supplyAsync(

--- a/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.exhort.integration.backend;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.*;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BackendUtilsTest {
+
+  private BackendUtils backendUtils;
+
+  @BeforeEach
+  void setUp() {
+    this.backendUtils = new BackendUtils();
+  }
+
+  @Test
+  void checkGeneratedWithLengthOf64AndHexaDecimalString() {
+
+    String requestId = this.backendUtils.generateRequestId(UUID.randomUUID().toString());
+    assertTrue(requestId.length() == 64);
+    assertTrue(allCharactersAreHexaDecimalDigits(requestId));
+  }
+
+  private boolean allCharactersAreHexaDecimalDigits(String requestId) {
+
+    return Arrays.stream(ArrayUtils.toObject(requestId.getBytes(StandardCharsets.UTF_8)))
+            .filter(
+                t -> // character is hexadecimal digit a-f
+                    (t.shortValue() >= 97 && t.shortValue() <= 102)
+                            // or char is one of 0-9 digits.
+                        || (t.shortValue() >= 48 && (t.shortValue() <= 57)))
+            .collect(Collectors.toList())
+            .size()
+        == requestId.length();
+  }
+
+  @Test
+  void checkGeneratedWithNoRHDATokenAndShouldBeDifferentFromEachOther() {
+
+    String reqId1 = this.backendUtils.generateRequestId(null);
+    String reqId2 = this.backendUtils.generateRequestId(null);
+    assertFalse(reqId1.equals(reqId2));
+  }
+
+  @Test
+  void checkGeneratedWithSameUuidRHDATokenAndDifferentTimeShouldBeDifferentFromEachOther() {
+
+    String randsomUUID = UUID.randomUUID().toString();
+    String reqId1 = this.backendUtils.generateRequestId(randsomUUID);
+    String reqId2 = this.backendUtils.generateRequestId(randsomUUID);
+    assertFalse(reqId1.equals(reqId2));
+  }
+
+  @Test
+  void checkGeneratedWithSameTimeDifferentRHDATokenAndDifferentFromEachOther() {
+
+    String randomUUID = UUID.randomUUID().toString();
+    String randomUUID2 = UUID.randomUUID().toString();
+    AtomicReference<String> reqId = new AtomicReference();
+    AtomicReference<String> reqId2 = new AtomicReference();
+    LocalDate fakeDate = LocalDate.of(2024, 1, 1);
+    Clock clock =
+        Clock.fixed(fakeDate.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+    this.backendUtils.setClock(clock);
+    Thread thread = new Thread(() -> reqId.set(this.backendUtils.generateRequestId(randomUUID)));
+    Thread thread2 = new Thread(() -> reqId2.set(this.backendUtils.generateRequestId(randomUUID2)));
+    thread.start();
+    thread2.start();
+
+    try {
+      thread.join();
+      thread2.join();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } finally {
+      this.backendUtils.setClock(null);
+    }
+    assertFalse(reqId.get().equals(reqId2.get()));
+  }
+
+  @Test
+  void checkGeneratedWithSameTimeSameRHDATokenAndTheyShouldBeEquals() {
+
+    String randomUUID = UUID.randomUUID().toString();
+
+    AtomicReference<String> reqId = new AtomicReference();
+    AtomicReference<String> reqId2 = new AtomicReference();
+    LocalDate fakeDate = LocalDate.of(2024, 1, 1);
+    Clock clock =
+        Clock.fixed(fakeDate.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+    this.backendUtils.setClock(clock);
+    Thread thread = new Thread(() -> reqId.set(this.backendUtils.generateRequestId(randomUUID)));
+    Thread thread2 = new Thread(() -> reqId2.set(this.backendUtils.generateRequestId(randomUUID)));
+    thread.start();
+    thread2.start();
+    try {
+      thread.join();
+      thread2.join();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } finally {
+      this.backendUtils.setClock(null);
+    }
+
+    assertTrue(reqId.get().equals(reqId2.get()));
+  }
+
+  @Test
+  void checkGeneratedWithSameTimeWithNullRHDATokenAndTheyShouldBeDifferent() {
+
+    String randomUUID = UUID.randomUUID().toString();
+
+    AtomicReference<String> reqId = new AtomicReference();
+    AtomicReference<String> reqId2 = new AtomicReference();
+    LocalDate fakeDate = LocalDate.of(2024, 1, 1);
+    Clock clock =
+        Clock.fixed(fakeDate.atStartOfDay().toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
+    this.backendUtils.setClock(clock);
+    Thread thread = new Thread(() -> reqId.set(this.backendUtils.generateRequestId(null)));
+    Thread thread2 = new Thread(() -> reqId2.set(this.backendUtils.generateRequestId(null)));
+    thread.start();
+    thread2.start();
+    try {
+      thread.join();
+      thread2.join();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } finally {
+      this.backendUtils.setClock(null);
+    }
+
+    assertNotEquals(reqId.get(), reqId2.get());
+  }
+}


### PR DESCRIPTION
1. Generate ex-request-id , a sha256 digest of the timestamp + rhda_token if exists ( otherwise random real number in the range of [0,1] ). 

2.  add this generated value as an exchange property ( Camel exchange property) called exRequestId.
3. propagate it to all original request message paths , all error messages and on all error paths as a metadata field with the name of the property.
4. add to the response of all paths and cases( 200, 422 , 5xx , etc.)  the value  of generted ex-request-id as a response header.

Handle: https://issues.redhat.com/browse/APPENG-2183.

_**Why not using UUID generator and that's it?**_
Because RHDA Token is already one of the metadata fields in logs messages sent to sentry, and usually clients send RHDA  Token as Pseudo random generated uuid, and we want a different pattern of randomly generated unique string not to be confused with RHDA Token:

1. The size is much bigger - 64 characters, hence it can be instantly looked up in the logs and found, without any fear for collision ( chances for collisions are very near to zero, much more close to zero than just standard UUID because of the string size).
2. It can't be confused with RHDA-TOKEN' UUID value as uuid' length  is much shorter and also with hyphens, and sha256 string digest is a string of  64 charcters long of hexadecimal characters.

 