### PR TITLE
fix: correct contained_by/contains relationships and filter duplicates in Snyk

### DIFF
--- a/src/main/java/com/redhat/exhort/integration/backend/sbom/spdx/SpdxParser.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/sbom/spdx/SpdxParser.java
@@ -165,7 +165,7 @@ public class SpdxParser extends SbomParser {
     static RelationshipDirection fromRelationshipType(RelationshipType type) {
       return switch (type) {
         case DEPENDS_ON,
-            CONTAINS,
+            CONTAINED_BY,
             BUILD_DEPENDENCY_OF,
             OPTIONAL_COMPONENT_OF,
             OPTIONAL_DEPENDENCY_OF,
@@ -174,7 +174,7 @@ public class SpdxParser extends SbomParser {
             RUNTIME_DEPENDENCY_OF,
             DEV_DEPENDENCY_OF,
             ANCESTOR_OF -> FORWARD;
-        case DEPENDENCY_OF, DESCENDANT_OF, PACKAGE_OF, CONTAINED_BY -> BACKWARDS;
+        case DEPENDENCY_OF, DESCENDANT_OF, PACKAGE_OF, CONTAINS -> BACKWARDS;
         default -> IGNORED;
       };
     }

--- a/src/main/java/com/redhat/exhort/integration/providers/snyk/SnykRequestBuilder.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/snyk/SnykRequestBuilder.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.camel.Body;
 import org.apache.camel.Exchange;
@@ -125,6 +126,8 @@ public class SnykRequestBuilder {
     var pkgs = mapper.createArrayNode().add(createPkg(root));
 
     refs.stream()
+        .collect(Collectors.toMap(k -> getId(k), v -> v, (a, b) -> a))
+        .values()
         .forEach(
             d -> {
               pkgs.add(createPkg(d));

--- a/src/test/java/com/redhat/exhort/integration/backend/sbom/SbomParserTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/sbom/SbomParserTest.java
@@ -136,8 +136,8 @@ public class SbomParserTest {
     var file = getClass().getClassLoader().getResourceAsStream(fileName);
 
     var tree = parser.buildTree(file);
-    assertEquals(4, tree.dependencies().size());
-    assertEquals(260, tree.transitiveCount());
+    assertEquals(260, tree.dependencies().size());
+    assertEquals(4, tree.transitiveCount());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Fix [APPENG-2282](https://issues.redhat.com/browse/APPENG-2282)