### PR TITLE
chore(deps): move to jvm build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install commitlint
         run: |
           npm install conventional-changelog-conventionalcommits
@@ -41,11 +41,11 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Run integration tests
         run: |
-          ./mvnw -B verify -Pnative
+          ./mvnw -B verify
         env:
           GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -18,13 +18,12 @@ env:
   IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
   IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
   # 🖊️ EDIT to change Dockerfile.
-  DOCKERFILE_PATH: ./src/main/docker/Dockerfile.native-micro
+  DOCKERFILE_PATH: ./src/main/docker/Dockerfile.jvm.staged
 
 on:
   push:
     branches:
       - main
-      - stable
     tags:
       - '*'
   workflow_dispatch:
@@ -88,7 +87,6 @@ jobs:
           branch=${GITHUB_REF_NAME}
           case ${branch} in
           'main') tag='latest' ;;
-          'stable') tag='alpha' ;;
           *) tag=${branch} ;;
           esac
           echo "tag=${tag}" >> $GITHUB_OUTPUT
@@ -98,12 +96,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
 
       - name: Build Package with Maven
         run: |
-          ./mvnw -B verify -Pnative
+          ./mvnw -B verify
         env:
           GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tekton/exhort-pull-request.yaml
+++ b/.tekton/exhort-pull-request.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: src/main/docker/Dockerfile.multi-stage
+    value: src/main/docker/Dockerfile.jvm.staged
   - name: git-url
     value: '{{repo_url}}'
   - name: image-expires-after

--- a/.tekton/exhort-push.yaml
+++ b/.tekton/exhort-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: src/main/docker/Dockerfile.multi-stage
+    value: src/main/docker/Dockerfile.jvm.staged
   - name: git-url
     value: '{{repo_url}}'
   - name: output-image

--- a/deploy/exhort.yaml
+++ b/deploy/exhort.yaml
@@ -27,7 +27,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: "128Mi"
+            memory: "512Mi"
             cpu: "500m"
         env:
         - name: API_SNYK_TOKEN

--- a/deploy/openshift/template.yaml
+++ b/deploy/openshift/template.yaml
@@ -179,7 +179,7 @@ parameters:
     description: The maximum amount of CPU the container can use.
     displayName: Memory Limit
     required: true
-    value: 500m
+    value: 1024Mi
   - name: MEMORY_REQUEST
     description: The minimum amount of memory required by a container
     displayName: Memory Limit
@@ -189,7 +189,7 @@ parameters:
     description: The maximum amount of memory the container can use.
     displayName: Memory Limit
     required: true
-    value: 1024Mi
+    value: 5120Mi
   - name: ENV_NAME
     value: stage
     displayName: Environment (default -- stage)

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <!-- Build properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>21</maven.compiler.release>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</maven.build.timestamp.format>
     <timestamp>${maven.build.timestamp}</timestamp>
     <skipITs>true</skipITs>
@@ -48,12 +48,12 @@
     <deploy-plugin.version>3.1.1</deploy-plugin.version>
 
     <!-- Dependencies -->
-    <exhort-api.version>1.0.5-SNAPSHOT</exhort-api.version>
+    <exhort-api.version>1.0.5</exhort-api.version>
     <sentry.version>1.7.27</sentry.version>
     <cyclonedx.version>8.0.3</cyclonedx.version>
     <spdx.version>1.1.7</spdx.version>
     <htmlunit.version>2.70.0</htmlunit.version>
-    <wiremock.version>3.3.1</wiremock.version>
+    <wiremock.version>3.4.2</wiremock.version>
 
     <!-- Node and Yarn -->
     <node.version>v20.9.0</node.version>
@@ -142,6 +142,10 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.slf4j</groupId>
+      <artifactId>slf4j-jboss-logmanager</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-direct</artifactId>
     </dependency>
@@ -182,6 +186,12 @@
       <groupId>org.spdx</groupId>
       <artifactId>spdx-jackson-store</artifactId>
       <version>${spdx.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j18-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.sentry</groupId>
@@ -197,12 +207,6 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -75,10 +75,9 @@
 #   accessed directly. (example: "foo.example.com,bar.example.com")
 #
 ###
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.16
+FROM registry.redhat.io/ubi9/openjdk-21:1.18
 
 ENV LANGUAGE='en_US:en'
-
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
 COPY --chown=185 target/quarkus-app/lib/ /deployments/lib/
@@ -91,3 +90,4 @@ USER 185
 ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/src/main/docker/Dockerfile.jvm.staged
+++ b/src/main/docker/Dockerfile.jvm.staged
@@ -1,0 +1,59 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Build the image with:
+#
+# docker build -f src/main/docker/Dockerfile.jvm.staged -t quarkus/code-with-quarkus-jvm .
+#
+# Then run the container using:
+#
+# docker run -i --rm -p 8081:8081 quarkus/code-with-quarkus-jvm
+#
+# If you want to include the debug port into your docker image
+# you will have to expose the debug port (default 5005) like this :  EXPOSE 8080 5050
+#
+# Then run the container using :
+#
+# docker run -i --rm -p 8080:8080 -p 9000:9000 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/code-with-quarkus-jvm
+#
+###
+FROM registry.redhat.io/ubi9/openjdk-21:1.18
+
+USER root
+WORKDIR /build
+
+## Maven Settings with the auth token for Github Maven Repository
+COPY settings.xml settings.xml
+COPY pom.xml .
+COPY ui ui
+
+RUN mvn -B --settings settings.xml org.apache.maven.plugins:maven-dependency-plugin:3.6.1:go-offline
+
+COPY src src
+
+RUN mvn verify -B
+
+RUN grep version /build/target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-version
+RUN grep artifactId /build/target/maven-archiver/pom.properties | cut -d '=' -f2 >.env-id
+
+# if this is an uber jar create a structure that looks the same as fast-jar with empty directories
+# this allows for the same dockerfile to be used with both
+RUN if [ ! -d /build/target/quarkus-app ] ; then mkdir -p /build/target/quarkus-app/lib; \
+     mkdir -p /build/target/quarkus-app/app; \
+     mkdir -p /build/target/quarkus-app/quarkus; \
+     mv /build/target/$(cat .env-id)-$(cat .env-version)*.jar /build/target/quarkus-app/ ; \
+     fi
+
+FROM registry.redhat.io/ubi9/openjdk-21-runtime:1.18
+# Configure the JAVA_OPTS, you can add -XshowSettings:vm to also display the heap size.
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --from=0 --chown=1001 /build/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=0 --chown=1001 /build/target/quarkus-app/*.jar /deployments/export-run-artifact.jar
+COPY --from=0 --chown=1001 /build/target/quarkus-app/app/ /deployments/app/
+COPY --from=0 --chown=1001 /build/target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+EXPOSE 9000
+
+ENTRYPOINT ["/opt/jboss/container/java/run/run-java.sh"]

--- a/src/main/docker/Dockerfile.multi-stage
+++ b/src/main/docker/Dockerfile.multi-stage
@@ -10,9 +10,9 @@ COPY --chown=quarkus:quarkus settings.xml /code/settings.xml
 
 USER quarkus
 WORKDIR /code
-RUN ./mvnw -B --settings /code/settings.xml org.apache.maven.plugins:maven-dependency-plugin:3.6.1:go-offline
+RUN ./mvnw -B -Pnative --settings /code/settings.xml org.apache.maven.plugins:maven-dependency-plugin:3.6.1:go-offline
 COPY --chown=quarkus:quarkus src /code/src
-RUN ./mvnw verify -B -Pnative -Dmaven.test.skip=true -Dquarkus.native.native-image-xmx=8g
+RUN ./mvnw verify -B -Dmaven.test.skip=true -Dquarkus.native.native-image-xmx=8g
 
 ## Stage 2 : create the docker final image
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3

--- a/src/main/java/com/redhat/exhort/analytics/AnalyticsService.java
+++ b/src/main/java/com/redhat/exhort/analytics/AnalyticsService.java
@@ -36,8 +36,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 import com.github.packageurl.PackageURL;
 import com.redhat.exhort.analytics.segment.Context;
@@ -58,7 +57,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 @RegisterForReflection
 public class AnalyticsService {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(AnalyticsService.class);
+  private static final Logger LOGGER = Logger.getLogger(AnalyticsService.class);
 
   private static final String ANONYMOUS_ID = "telemetry-anonymous-id";
   private static final String ANALYSIS_EVENT = "rhda.exhort.analysis";

--- a/src/main/java/com/redhat/exhort/integration/backend/sbom/cyclonedx/CycloneDxParser.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/sbom/cyclonedx/CycloneDxParser.java
@@ -32,8 +32,7 @@ import java.util.stream.Collectors;
 
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.exhort.api.PackageRef;
@@ -48,7 +47,7 @@ import jakarta.ws.rs.core.Response;
 public class CycloneDxParser extends SbomParser {
 
   private static final ObjectMapper mapper = ObjectMapperProducer.newInstance();
-  private static final Logger LOGGER = LoggerFactory.getLogger(CycloneDxParser.class);
+  private static final Logger LOGGER = Logger.getLogger(CycloneDxParser.class);
 
   @Override
   protected DependencyTree buildTree(InputStream input) {
@@ -143,7 +142,7 @@ public class CycloneDxParser extends SbomParser {
         .forEach(
             v -> {
               if (deps.containsKey(v)) {
-                LOGGER.debug("Ignore duplicate key {}", v);
+                LOGGER.debugf("Ignore duplicate key %s", v);
               }
               deps.put(v, DirectDependency.builder().ref(v).build());
             });

--- a/src/main/java/com/redhat/exhort/integration/backend/sbom/spdx/SpdxParser.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/sbom/spdx/SpdxParser.java
@@ -28,8 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 import org.spdx.jacksonstore.MultiFormatStore;
 import org.spdx.jacksonstore.MultiFormatStore.Format;
 import org.spdx.library.InvalidSPDXAnalysisException;
@@ -47,7 +46,7 @@ import jakarta.ws.rs.core.Response;
 
 public class SpdxParser extends SbomParser {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SpdxParser.class);
+  private static final Logger LOGGER = Logger.getLogger(SpdxParser.class);
 
   @Override
   protected DependencyTree buildTree(InputStream input) {
@@ -58,7 +57,7 @@ public class SpdxParser extends SbomParser {
       var tree = new DependencyTree(deps);
       return tree;
     } catch (SpdxValidationException e) {
-      LOGGER.info("Invalid SPDX SBOM received", e.getMessage());
+      LOGGER.info("Invalid SPDX SBOM received", e);
       throw new ClientErrorException(e.getMessage(), Response.Status.BAD_REQUEST);
     } catch (SpdxProcessingException | InvalidSPDXAnalysisException | IOException e) {
       LOGGER.warn("Unable to parse the SPDX SBOM file", e);

--- a/src/main/java/com/redhat/exhort/integration/providers/ProviderResponseHandler.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/ProviderResponseHandler.java
@@ -34,8 +34,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangeProperty;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.http.base.HttpOperationFailedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 import com.redhat.exhort.api.PackageRef;
 import com.redhat.exhort.api.v4.DependencyReport;
@@ -70,7 +69,7 @@ public abstract class ProviderResponseHandler {
 
   public static final String AFFECTED_STATUS = "Affected";
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ProviderResponseHandler.class);
+  private static final Logger LOGGER = Logger.getLogger(ProviderResponseHandler.class);
 
   @Inject MonitoringProcessor monitoringProcessor;
 

--- a/src/main/java/com/redhat/exhort/integration/providers/ossindex/OssIndexResponseHandler.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/ossindex/OssIndexResponseHandler.java
@@ -29,8 +29,7 @@ import java.util.stream.Collectors;
 
 import org.apache.camel.Body;
 import org.apache.camel.ExchangeProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -53,7 +52,7 @@ import jakarta.inject.Inject;
 @RegisterForReflection
 public class OssIndexResponseHandler extends ProviderResponseHandler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(OssIndexRequestBuilder.class);
+  private static final Logger LOGGER = Logger.getLogger(OssIndexRequestBuilder.class);
 
   @Inject ObjectMapper mapper;
 
@@ -72,7 +71,9 @@ public class OssIndexResponseHandler extends ProviderResponseHandler {
         tree.getAll().stream()
             .collect(
                 Collectors.toMap(
-                    d -> new PackageRef(d.toString()).purl().getCoordinates(), d -> d));
+                    d -> new PackageRef(d.toString()).purl().getCoordinates(),
+                    d -> d,
+                    (a, b) -> a));
     response.forEach(
         n -> {
           var pkgRef = n.get("coordinates").asText();

--- a/src/main/java/com/redhat/exhort/integration/providers/snyk/SnykRequestBuilder.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/snyk/SnykRequestBuilder.java
@@ -33,8 +33,7 @@ import java.util.stream.Collectors;
 
 import org.apache.camel.Body;
 import org.apache.camel.Exchange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -51,7 +50,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @RegisterForReflection
 public class SnykRequestBuilder {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SnykRequestBuilder.class);
+  private static final Logger LOGGER = Logger.getLogger(SnykRequestBuilder.class);
 
   private static final String GOMODULES_PKG_MANAGER = "gomodules";
   private static final String RUBYGEMS_PKG_MANAGER = "rubygems";
@@ -106,7 +105,7 @@ public class SnykRequestBuilder {
     var invalidTypes =
         types.stream().filter(Predicate.not(SUPPORTED_PURL_TYPES::contains)).toList();
     if (!invalidTypes.isEmpty()) {
-      LOGGER.debug("Unsupported package url types received: {}", invalidTypes);
+      LOGGER.debugf("Unsupported package url types received: %s", invalidTypes);
       exchange.setProperty(
           Constants.UNSCANNED_REFS_PROPERTY,
           tree.stream()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,21 +32,7 @@ quarkus.rest-client.segment-api.url=https://api.segment.io/
 # monitoring.sentry.servername=local
 # monitoring.sentry.environment=development
 
-## Native configuration
-## See https://quarkus.io/guides/native-and-ssl
-quarkus.ssl.native=true
-quarkus.native.resources.includes=freemarker/templates/*.tfl
 quarkus.management.enabled=true
 quarkus.http.limits.max-body-size=4G
-quarkus.index-dependency.cyclonedx.group-id=org.cyclonedx
-quarkus.index-dependency.cyclonedx.artifact-id=cyclonedx-core-java
-quarkus.index-dependency.spdx-jackson.group-id=org.spdx
-quarkus.index-dependency.spdx-jackson.artifact-id=spdx-jackson-store
-quarkus.index-dependency.spdx-java.group-id=org.spdx
-quarkus.index-dependency.spdx-java.artifact-id=java-spdx-library
-quarkus.index-dependency.exhort-api.group-id=com.redhat.ecosystemappeng
-quarkus.index-dependency.exhort-api.artifact-id=exhort-api-spec
-quarkus.camel.native.reflection.include-patterns=org.cyclonedx.model.*,com.redhat.exhort.api.*,com.redhat.exhort.api.v3.*,com.redhat.exhort.api.v4.*,org.spdx.jacksonstore.*,org.spdx.storage.listedlicense.*
-# quarkus.jackson.serialization-inclusion=non-empty
 
 trustedcontent.recommended.ubi=pkg:oci/registry.access.redhat.com/ubi9/ubi@latest

--- a/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
@@ -36,7 +36,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 
@@ -44,7 +47,6 @@ import org.apache.camel.Exchange;
 import org.cyclonedx.CycloneDxMediaType;
 import org.junit.jupiter.api.AfterEach;
 
-import com.github.jknack.handlebars.internal.Files;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.google.common.base.Charsets;
@@ -107,12 +109,12 @@ public abstract class AbstractAnalysisTest {
     }
   }
 
-  protected void assertHtml(String expectedFile, String currentBody) {
+  protected void assertHtml(String expectedFile, String currentBody) throws URISyntaxException {
     String expected;
     try {
       expected =
-          Files.read(
-              getClass().getClassLoader().getResourceAsStream("__files/" + expectedFile),
+          Files.readString(
+              Path.of(getClass().getClassLoader().getResource("__files/" + expectedFile).toURI()),
               Charset.defaultCharset());
       expected = expected.replaceAll(WIREMOCK_URL_TEMPLATE, server.baseUrl());
       assertEquals(expected, currentBody);
@@ -155,8 +157,9 @@ public abstract class AbstractAnalysisTest {
 
   protected String loadFileAsString(String file) {
     try {
-      return Files.read(getClass().getClassLoader().getResourceAsStream(file), Charsets.UTF_8);
-    } catch (IOException e) {
+      return Files.readString(
+          Path.of(getClass().getClassLoader().getResource(file).toURI()), Charsets.UTF_8);
+    } catch (IOException | URISyntaxException e) {
       fail("Unable to read expected file: " + file, e);
       return null;
     }


### PR DESCRIPTION
There is no need to maintain the native build. Moving to simpler JVM builds.

* Moved to jboss.Logging because there were duplicated LoggingManagers in the classpath
* Upgraded builds to Java 21 and node 20
* Fixed wrong import for the `Files` helper in test classes