### PR TITLE
fix: reuse Hub instances for Sentry events

### DIFF
--- a/src/main/java/com/redhat/exhort/monitoring/SentryMonitoringClientFactory.java
+++ b/src/main/java/com/redhat/exhort/monitoring/SentryMonitoringClientFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import com.redhat.exhort.monitoring.impl.SentryMonitoringClient;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.sentry.Hub;
 import io.sentry.SentryOptions;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -47,6 +48,6 @@ public class SentryMonitoringClientFactory {
     opt.setDsn(dsn.get());
     opt.setEnvironment(environment);
     opt.setTag("server_name", serverName.get());
-    return new SentryMonitoringClient(opt);
+    return new SentryMonitoringClient(new Hub(opt));
   }
 }

--- a/src/main/java/com/redhat/exhort/monitoring/impl/SentryMonitoringClient.java
+++ b/src/main/java/com/redhat/exhort/monitoring/impl/SentryMonitoringClient.java
@@ -25,21 +25,19 @@ import com.redhat.exhort.monitoring.MonitoringContext;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.sentry.Hub;
-import io.sentry.SentryOptions;
 import io.sentry.protocol.User;
 
 @RegisterForReflection
 public class SentryMonitoringClient implements MonitoringClient {
 
-  private final SentryOptions options;
+  private final Hub hub;
 
-  public SentryMonitoringClient(SentryOptions options) {
-    this.options = options;
+  public SentryMonitoringClient(Hub hub) {
+    this.hub = hub;
   }
 
   @Override
   public void reportException(Throwable exception, MonitoringContext context) {
-    var hub = new Hub(options);
     if (!context.breadcrumbs().isEmpty()) {
       context.breadcrumbs().forEach(b -> hub.addBreadcrumb(b));
     }


### PR DESCRIPTION
Fix [APPENG-2391](https://issues.redhat.com/browse/APPENG-2391)

Introduced by https://github.com/RHEcosystemAppEng/exhort/pull/314